### PR TITLE
Removing Warnings and Errors messages during startup of the MiR Sim

### DIFF
--- a/mir_description/config/joint_state_controller.yaml
+++ b/mir_description/config/joint_state_controller.yaml
@@ -6,3 +6,7 @@ joint_state_controller:
 #gazebo_ros_control/pid_gains:
   #left_wheel_joint: {p: 100.0, i: 0.01, d: 10.0}
   #right_wheel_joint: {p: 100.0, i: 0.01, d: 10.0}
+
+gazebo_ros_control/pid_gains:
+  left_wheel_joint: {p: 1.0}
+  right_wheel_joint: {p: 1.0}

--- a/mir_navigation/config/costmap_global_params.yaml
+++ b/mir_navigation/config/costmap_global_params.yaml
@@ -1,6 +1,5 @@
 global_costmap:
     global_frame: map
-    static_map: true
     update_frequency: 1.0
     publish_frequency: 1.0
     raytrace_range: 2.0

--- a/mir_navigation/config/costmap_local_params.yaml
+++ b/mir_navigation/config/costmap_local_params.yaml
@@ -1,6 +1,5 @@
 local_costmap:
     global_frame: $(arg prefix)odom_comb
-    static_map: false
     rolling_window: true
     raytrace_range: 6.0
     resolution: 0.05

--- a/mir_navigation/config/dwa_local_planner_params.yaml
+++ b/mir_navigation/config/dwa_local_planner_params.yaml
@@ -7,21 +7,21 @@ DWAPlannerROS:
   max_vel_y: 0.0  # diff drive robot
   min_vel_y: 0.0  # diff drive robot
 
-  max_trans_vel: 0.8  # choose slightly less than the base's capability
-  min_trans_vel: 0.1  # this is the min trans velocity when there is negligible rotational velocity
+  max_vel_trans: 0.8  # choose slightly less than the base's capability
+  min_vel_trans: 0.1  # this is the min trans velocity when there is negligible rotational velocity
   trans_stopped_vel: 0.03
 
   # Warning!
   #   do not set min_trans_vel to 0.0 otherwise dwa will always think translational velocities
   #   are non-negligible and small in place rotational velocities will be created.
 
-  max_rot_vel: 1.0  # choose slightly less than the base's capability
-  min_rot_vel: 0.1  # this is the min angular velocity when there is negligible translational velocity
-  rot_stopped_vel: 0.1
+  max_vel_theta: 1.0  # choose slightly less than the base's capability
+  min_vel_theta: 0.1  # this is the min angular velocity when there is negligible translational velocity
+  theta_stopped_vel: 0.1
   
   acc_lim_x: 1.5
   acc_lim_y: 0.0      # diff drive robot
-  acc_limit_trans: 1.5
+  acc_lim_trans: 1.5
   acc_lim_theta: 2.0
 
   # Goal tolerance

--- a/mir_navigation/launch/mir_launch/start_maps.launch
+++ b/mir_navigation/launch/mir_launch/start_maps.launch
@@ -2,6 +2,6 @@
   <arg name="map_file" default="$(find mir_gazebo)/maps/pp_test_5.yaml" doc="Path to a map .yaml file (required)." />
   
   <node name="static_map_server" pkg="map_server" type="map_server" args="$(arg map_file)" ns="/" output="screen">
-    <param name="frame_id" type="string" value="/map"/>
+    <param name="frame_id" type="string" value="map"/>
   </node>
 </launch>


### PR DESCRIPTION
- Added PID-params with p-value=1 for left_wheel_joint and right_wheel_joint
-  Removed depracated "static_map" param from global and local costmap -  Changed param names in dwa_local_planner_params Those params were renamed, the old ones are deprecated.
- frame_id in static_map_server was wrong (/map instead of map)
- Renamed depracated params in dwa_local_planner_params